### PR TITLE
Update main.yml

### DIFF
--- a/debian-base/tasks/main.yml
+++ b/debian-base/tasks/main.yml
@@ -5,4 +5,4 @@
   apt: pkg=heirloom-mailx cache_valid_time=3600
 
 - name: Set unattended-upgrades conf
-  template: src=50unattended-upgrades.j2 dest=/etc/apt/apt.conf.d/
+  template: src=50unattended-upgrades.j2 dest=/etc/apt/apt.conf.d/50unattended-upgrades


### PR DESCRIPTION
Without this, the file gets deployed as ".j2" on the server, thus not overwriting the default file.